### PR TITLE
Update MANIFEST.in to add templates in the package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include requirements.txt
 include napalm_vyos/templates/*.j2
+include napalm_vyos/templates/*.template
 include napalm_vyos/utils/textfsm_templates/*.tpl


### PR DESCRIPTION
I fixed an issue when installing the package, the templates dir wasn't getting included, resulting in :
```
FileNotFoundError: [Errno 2] No such file or directory: '/xxx/venv/lib/python3.11/site-packages/napalm_vyos/templates/bgp_sum.template'
```

## Summary by Sourcery

Bug Fixes:
- Fix package installation by ensuring templates directory is included in the package distribution