### PR TITLE
Fix BGP summary template for recent versions of VyOS

### DIFF
--- a/napalm_vyos/templates/bgp_sum.template
+++ b/napalm_vyos/templates/bgp_sum.template
@@ -14,7 +14,7 @@ Value Required PREFIX_SENT (\d+)
 Value Required DESCRIPTION (.+)
 
 Start
-  ^BGP router identifier ${BGP_ROUTER_ID}, local AS number ${LOCAL_AS} vrf-id ${VRF_ID} -> Neighbors
+  ^BGP router identifier ${BGP_ROUTER_ID}, local AS number ${LOCAL_AS} .* vrf-id ${VRF_ID} -> Neighbors
 
 Neighbors
   ^Neighbor\s+V\s+AS\s+MsgRcvd\s+MsgSent\s+TblVer\s+InQ\s+OutQ\s+Up/Down\s+State/PfxRcd\s+PfxSnt\s+Desc -> PeerLine


### PR DESCRIPTION
Recent versions of VyOS will add the name of the current VRF inside the summary, breaking the template, this change add a wildcard inside the line, that will allow any VRF name and stop the template from not rendering anything

## Summary by Sourcery

Bug Fixes:
- Fix parsing of BGP summary template for recent VyOS versions by adding a wildcard to accommodate VRF name variations