### PR TITLE
Allows for using the module without peering-manager

### DIFF
--- a/napalm_vyos/vyos.py
+++ b/napalm_vyos/vyos.py
@@ -24,14 +24,15 @@ import re
 import tempfile
 import textfsm
 import vyattaconfparser
+try:
+    import logging
+    logger = logging.getLogger("peering.manager.peering")
 
-import logging
-logger = logging.getLogger("peering.manager.peering")
+    from django.core.cache import cache
 
-from django.core.cache import cache
-
-cache.clear()
-
+    cache.clear()
+except Exception:
+    pass
 # NAPALM base
 import napalm.base.constants as C
 from napalm.base.base import NetworkDriver


### PR DESCRIPTION
This pull request modifies the `napalm_vyos/vyos.py` file to handle potential import errors more gracefully by wrapping certain imports in a `try-except` block.

Error handling improvements:

* Wrapped the import of the `logging` module and the subsequent logger setup, as well as the `cache.clear()` call, in a `try-except` block to prevent the script from failing if an exception occurs during these operations. If an exception is raised, it is caught and ignored.

## Summary by Sourcery

Enhancements:
- Add graceful error handling for import and initialization operations to allow the module to function even when certain dependencies are not available