### PR TITLE
Fix IPv6 neigbour informations

### DIFF
--- a/napalm_vyos/vyos.py
+++ b/napalm_vyos/vyos.py
@@ -460,7 +460,7 @@ class VyOSDriver(NetworkDriver):
         192.168.1.4     4 64522       0       0        0    0    0 never    Active
         """
 
-        output = self.device.send_command("show ip bgp summary")
+        output = self.device.send_command("show bgp summary")
 
         current_dir = os.path.dirname(os.path.abspath(__file__))
         template_path = os.path.join(current_dir, "templates", "bgp_sum.template")
@@ -513,7 +513,7 @@ class VyOSDriver(NetworkDriver):
 
         for neighbor in neighbors["global"]["peers"]:
 
-            output = self.device.send_command(f"show ip bgp neighbor {neighbor}")
+            output = self.device.send_command(f"show bgp neighbor {neighbor}")
 
             current_dir = os.path.dirname(os.path.abspath(__file__))
             template_path = os.path.join(
@@ -542,7 +542,7 @@ class VyOSDriver(NetworkDriver):
                         "remote_as": int(neighbor_detail["REMOTE_AS"]),
                         "router_id": neighbor_detail["LOCAL_ROUTER_ID"],
                         "local_address": neighbor_detail[
-                            "LOCAL_ROUTER_ID"
+                            "LOCAL_HOST"
                         ],  # Adjusted from LOCAL_ROUTER_ID based on context
                         "routing_table": f"IPv{neighbor_detail['BGP_VERSION']} Unicast",  # Constructed value
                         "local_address_configured": bool(neighbor_detail["LOCAL_ROUTER_ID"]),


### PR DESCRIPTION
Code wasn't made for Ipv6 totally in mind, those fixes fix that (As well as fixing the local address of all the sessions that are not using the router id as address)

--


This pull request updates the `napalm_vyos/vyos.py` file to align with changes in command syntax and improve data accuracy. The most important changes include modifying BGP-related commands and adjusting the data mapping for local addresses.

### Updates to BGP command syntax:
* Updated the command for retrieving BGP summary information from `show ip bgp summary` to `show bgp summary` to reflect the current syntax. (`[napalm_vyos/vyos.pyL463-R463](diffhunk://#diff-6d7a6e26bea2dc9aef601c22436b8e1de29a9700e68fd435bc60ff3a1000de48L463-R463)`)
* Updated the command for retrieving BGP neighbor details from `show ip bgp neighbor` to `show bgp neighbor` to align with the updated syntax. (`[napalm_vyos/vyos.pyL516-R516](diffhunk://#diff-6d7a6e26bea2dc9aef601c22436b8e1de29a9700e68fd435bc60ff3a1000de48L516-R516)`)

### Adjustments to data mapping:
* Changed the mapping for the `local_address` field from `LOCAL_ROUTER_ID` to `LOCAL_HOST` to better match the context of the data being represented. (`[napalm_vyos/vyos.pyL545-R545](diffhunk://#diff-6d7a6e26bea2dc9aef601c22436b8e1de29a9700e68fd435bc60ff3a1000de48L545-R545)`)

## Summary by Sourcery

Update VyOS BGP neighbor information retrieval to support IPv6 and improve local address mapping

Bug Fixes:
- Fix BGP command syntax to work with both IPv4 and IPv6 network configurations
- Correct local address mapping for BGP neighbor information

Enhancements:
- Update BGP command syntax to use more generic 'show bgp' commands instead of 'show ip bgp'
- Improve local address field mapping to use 'LOCAL_HOST' instead of 'LOCAL_ROUTER_ID'