### PR TITLE
Fixing the prefix counts using prefix count command

### DIFF
--- a/napalm_vyos/templates/bgp_prefix_counts.template
+++ b/napalm_vyos/templates/bgp_prefix_counts.template
@@ -1,0 +1,26 @@
+Value NEIGHBOR_IP (\S+)
+Value ADJ_IN (\d+)
+Value DAMPED (\d+)
+Value REMOVED (\d+)
+Value HISTORY (\d+)
+Value STALE (\d+)
+Value VALID (\d+)
+Value ALL_RIB (\d+)
+Value PFXCT_COUNTED (\d+)
+Value BEST_SELECTED (\d+)
+Value USEABLE (\d+)
+Value UNSORTED (\d+)
+
+Start
+  ^Prefix counts for ${NEIGHBOR_IP}, IPv[4,6] Unicast
+  ^\s*Adj-in:\s+${ADJ_IN}
+  ^\s*Damped:\s+${DAMPED}
+  ^\s*Removed:\s+${REMOVED}
+  ^\s*History:\s+${HISTORY}
+  ^\s*Stale:\s+${STALE}
+  ^\s*Valid:\s+${VALID}
+  ^\s*All RIB:\s+${ALL_RIB}
+  ^\s*PfxCt counted:\s+${PFXCT_COUNTED}
+  ^\s*PfxCt Best Selected:\s+${BEST_SELECTED}
+  ^\s*Useable:\s+${USEABLE}
+  ^\s*Unsorted:\s+${UNSORTED}

--- a/napalm_vyos/vyos.py
+++ b/napalm_vyos/vyos.py
@@ -499,6 +499,26 @@ class VyOSDriver(NetworkDriver):
 
         return bgp_neighbor_data
 
+    def get_bgp_neighbor_prefix_counts(self, neighbor_address):
+        output = self.device.send_command(f"show bgp {self._get_ip_version(neighbor_address)} neighbor {neighbor_address} prefix-counts")
+
+        current_dir = os.path.dirname(os.path.abspath(__file__))
+        template_path = os.path.join(
+            current_dir, "templates", "bgp_prefix_counts.template"
+        )
+
+        with open(template_path) as template_file:
+            fsm = textfsm.TextFSM(template_file)
+            result = fsm.ParseText(output)
+
+            if not result:
+                return {}
+
+            neighbor_dict = dict(zip(fsm.header, result[0]))
+            
+
+        return neighbor_dict
+
     def get_bgp_neighbors_detail(self, neighbor_address=""):
 
         def safe_int(value, default=0):
@@ -512,13 +532,15 @@ class VyOSDriver(NetworkDriver):
         neighbors = self.get_bgp_neighbors()
 
         for neighbor in neighbors["global"]["peers"]:
-
-            output = self.device.send_command(f"show ip bgp neighbor {neighbor}")
+            neighbor_obj = neighbors["global"]["peers"].get(neighbor)
+            output = self.device.send_command(f"show bgp {self._get_ip_version(neighbor)} neighbor {neighbor}")
 
             current_dir = os.path.dirname(os.path.abspath(__file__))
             template_path = os.path.join(
                 current_dir, "templates", "bgp_details.template"
             )
+
+            neighbor_prefix_counts = self.get_bgp_neighbor_prefix_counts(neighbor)
 
             with open(template_path) as template_file:
                 fsm = textfsm.TextFSM(template_file)
@@ -542,7 +564,7 @@ class VyOSDriver(NetworkDriver):
                         "remote_as": int(neighbor_detail["REMOTE_AS"]),
                         "router_id": neighbor_detail["LOCAL_ROUTER_ID"],
                         "local_address": neighbor_detail[
-                            "LOCAL_ROUTER_ID"
+                            "LOCAL_HOST"
                         ],  # Adjusted from LOCAL_ROUTER_ID based on context
                         "routing_table": f"IPv{neighbor_detail['BGP_VERSION']} Unicast",  # Constructed value
                         "local_address_configured": bool(neighbor_detail["LOCAL_ROUTER_ID"]),
@@ -601,16 +623,16 @@ class VyOSDriver(NetworkDriver):
                             neighbor_detail["CONFIGURED_KEEPALIVE_INTERVAL"]
                         ),
                         "active_prefix_count": int(
-                            neighbor_detail.get("ACTIVE_PREFIX_COUNT", 0)
+                            neighbor_prefix_counts.get("BEST_SELECTED", 0)
                         ),  # Assuming ACTIVE_PREFIX_COUNT is available
                         "accepted_prefix_count": int(
-                            neighbor_detail.get("ACCEPTED_PREFIX_COUNT", 0)
+                            neighbor_prefix_counts.get("USEABLE", 0)
                         ),  # Assuming ACCEPTED_PREFIX_COUNT is available
                         "suppressed_prefix_count": int(
-                            neighbor_detail.get("SUPPRESSED_PREFIX_COUNT", 0)
+                            neighbor_prefix_counts.get("REMOVED", 0)
                         ),  # Assuming SUPPRESSED_PREFIX_COUNT is available
                         "advertised_prefix_count": int(
-                            neighbor_detail.get("ADVERTISED_PREFIX_COUNT", 0)
+                            neighbor_obj.get("advertised_prefix_count", 0)
                         ),
                         "received_prefix_count": safe_int(
                             neighbor_detail.get("RECEIVED_PREFIXES_IPV4", 0)


### PR DESCRIPTION
This pull request introduces functionality to retrieve and parse BGP neighbor prefix count details in the `napalm_vyos` driver. It includes the addition of a new TextFSM template, a new method for parsing prefix counts, and updates to the existing `get_bgp_neighbors_detail` method to incorporate the new data.

### New functionality for BGP neighbor prefix counts:

* Added a new TextFSM template `bgp_prefix_counts.template` to parse BGP prefix count details from CLI output. The template extracts various metrics such as `ADJ_IN`, `DAMPED`, `REMOVED`, and others.
* Introduced a new method `get_bgp_neighbor_prefix_counts` in `napalm_vyos/vyos.py` to process BGP prefix count data using the new template. This method parses the command output and returns a dictionary of prefix count details.

### Updates to `get_bgp_neighbors_detail`:

* Integrated the new `get_bgp_neighbor_prefix_counts` method into `get_bgp_neighbors_detail` to fetch and include prefix count data for each neighbor.
* Adjusted the `local_address` field in the returned neighbor details to use the `LOCAL_HOST` value instead of `LOCAL_ROUTER_ID`.
* Updated prefix count fields (`active_prefix_count`, `accepted_prefix_count`, `suppressed_prefix_count`, etc.) to use values from the new prefix count data or fallback to existing fields.

## Summary by Sourcery

Enhance BGP neighbor prefix count retrieval in the napalm_vyos driver by adding a new method to parse prefix count details and integrating it into the existing BGP neighbors detail method.

New Features:
- Add a new method `get_bgp_neighbor_prefix_counts` to retrieve detailed prefix count information for BGP neighbors

Enhancements:
- Improve BGP neighbor details retrieval by incorporating more accurate prefix count information
- Update the local address retrieval to use LOCAL_HOST instead of LOCAL_ROUTER_ID

Chores:
- Add a new TextFSM template for parsing BGP prefix count details